### PR TITLE
[package] redux 도입

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -1,30 +1,21 @@
-"use client";
-
 import { Header, Footer } from "../components";
 import styles from "../styles/layout.module.css";
 import "../styles/globals.css";
-import { useRef } from "react";
-import { Provider } from "react-redux";
-import { makeStore } from "@/lib/store";
+import ReduxProvider from "@/lib/provider";
 
-const metadata = {
+export const metadata = {
   title: "한양대학교 데이터 포털",
 };
 
 export default function Layout({ children }) {
-  const storeRef = useRef();
-  if (!storeRef.current) {
-    storeRef.current = makeStore();
-  }
-
   return (
     <html lang="ko">
       <body>
         <div className={styles.container}>
           <Header />
-          <Provider store={storeRef.current}>
-            <div className={styles.content}>{children}</div>
-          </Provider>
+          <div className={styles.content}>
+            <ReduxProvider>{children}</ReduxProvider>
+          </div>
           <Footer />
         </div>
       </body>

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -1,18 +1,30 @@
+"use client";
+
 import { Header, Footer } from "../components";
 import styles from "../styles/layout.module.css";
 import "../styles/globals.css";
+import { useRef } from "react";
+import { Provider } from "react-redux";
+import { makeStore } from "@/lib/store";
 
-export const metadata = {
+const metadata = {
   title: "한양대학교 데이터 포털",
 };
 
 export default function Layout({ children }) {
+  const storeRef = useRef();
+  if (!storeRef.current) {
+    storeRef.current = makeStore();
+  }
+
   return (
     <html lang="ko">
       <body>
         <div className={styles.container}>
           <Header />
-          <div className={styles.content}>{children}</div>
+          <Provider store={storeRef.current}>
+            <div className={styles.content}>{children}</div>
+          </Provider>
           <Footer />
         </div>
       </body>

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -11,13 +11,13 @@ export default function Layout({ children }) {
   return (
     <html lang="ko">
       <body>
-        <div className={styles.container}>
-          <Header />
-          <div className={styles.content}>
-            <ReduxProvider>{children}</ReduxProvider>
+        <ReduxProvider>
+          <div className={styles.container}>
+            <Header />
+            <div className={styles.content}>{children}</div>
+            <Footer />
           </div>
-          <Footer />
-        </div>
+        </ReduxProvider>
       </body>
     </html>
   );

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,19 +1,26 @@
-import { currentOpenDataDummy } from "../dummy-data/main-datas";
+"use client";
+
+import { useEffect, useState } from "react";
 import Home from "./home";
 
-async function getListData() {
-  // TODO: server api fetch
-  const res = await fetch(`https://jsonplaceholder.typicode.com/posts`);
-  const all = await res.json();
-  const listData = all.slice(0, 5).map((value) => ({
-    id: value.id,
-    label: "일반행정",
-    title: value.title,
-  }));
-  return listData;
-}
-
 export default async function Page() {
-  const listData = await getListData();
+  const [listData, setListData] = useState();
+
+  useEffect(() => {
+    async function fetchListData() {
+      // TODO: server api fetch
+      const res = await fetch(`https://jsonplaceholder.typicode.com/posts`);
+      const all = await res.json();
+      const listData = all.slice(0, 5).map((value) => ({
+        id: value.id,
+        label: "일반행정",
+        title: value.title,
+      }));
+      setListData(listData);
+    }
+
+    fetchListData();
+  }, []);
+
   return <Home listData={listData} />;
 }

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,26 +1,19 @@
-"use client";
-
-import { useEffect, useState } from "react";
+import { currentOpenDataDummy } from "../dummy-data/main-datas";
 import Home from "./home";
 
+async function getListData() {
+  // TODO: server api fetch
+  const res = await fetch(`https://jsonplaceholder.typicode.com/posts`);
+  const all = await res.json();
+  const listData = all.slice(0, 5).map((value) => ({
+    id: value.id,
+    label: "일반행정",
+    title: value.title,
+  }));
+  return listData;
+}
+
 export default async function Page() {
-  const [listData, setListData] = useState();
-
-  useEffect(() => {
-    async function fetchListData() {
-      // TODO: server api fetch
-      const res = await fetch(`https://jsonplaceholder.typicode.com/posts`);
-      const all = await res.json();
-      const listData = all.slice(0, 5).map((value) => ({
-        id: value.id,
-        label: "일반행정",
-        title: value.title,
-      }));
-      setListData(listData);
-    }
-
-    fetchListData();
-  }, []);
-
+  const listData = await getListData();
   return <Home listData={listData} />;
 }

--- a/src/app/test-page/page.jsx
+++ b/src/app/test-page/page.jsx
@@ -1,9 +1,9 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 import { useAppSelector } from "@/lib/hooks";
-import { login, logout, updateToken } from "@/lib/slice/auth-slice";
+import { login, logout } from "@/lib/slice/auth-slice";
 import { dataset as result } from "@/dummy-data/datasets";
 import { BarChart } from "@/components";
 
@@ -45,7 +45,6 @@ export default function Test() {
           유저 정보 삭제 submit
         </button>
       </div>
-      <BarChart x_axis_name={result.x_axis_name} dataset={result} />
     </>
   );
 }

--- a/src/app/test-page/page.jsx
+++ b/src/app/test-page/page.jsx
@@ -1,9 +1,51 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
+import { useAppSelector } from "@/lib/hooks";
+import { login, logout, updateToken } from "@/lib/slice/auth-slice";
 import { dataset as result } from "@/dummy-data/datasets";
 import { BarChart } from "@/components";
 
 export default function Test() {
-  return <BarChart x_axis_name={result.x_axis_name} dataset={result} />;
+  const { isActive, accessToken, role } = useAppSelector(
+    (state) => state.authReducer.value,
+  );
+  const [username, setUsername] = useState();
+  const dispatch = useDispatch();
+
+  const onSubmit = () => {
+    dispatch(login(username));
+  };
+
+  const onRemoveSubmit = () => {
+    dispatch(logout());
+  };
+
+  return (
+    <>
+      <div>
+        <p>store에 저장된 isActive: {isActive ? "login" : "logout"}</p>
+        <p>store에 저장된 accessToken: {accessToken}</p>
+        <p>store에 저장된 role: {role}</p>
+      </div>
+      <input
+        type="text"
+        placeholder="유저 아이디 입력"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+      />
+      <div>
+        <button type="button" onClick={onSubmit}>
+          유저 이름 submit
+        </button>
+      </div>
+      <div>
+        <button type="button" onClick={onRemoveSubmit}>
+          유저 정보 삭제 submit
+        </button>
+      </div>
+      <BarChart x_axis_name={result.x_axis_name} dataset={result} />
+    </>
+  );
 }

--- a/src/components/header/header.jsx
+++ b/src/components/header/header.jsx
@@ -5,8 +5,21 @@ import { MainLogo } from "../../../public/svgs";
 import Image from "next/image";
 import { VerticalDivider } from "../vertical-divider/vertical-divider";
 import Link from "next/link";
+import { useAppSelector } from "@/lib/hooks";
+import { useDispatch } from "react-redux";
+import { logout } from "@/lib/slice/auth-slice";
 
 export function Header() {
+  const { isActive, accessToken, role } = useAppSelector(
+    (state) => state.authReducer.value,
+  );
+  const dispatch = useDispatch();
+
+  const onLogout = () => {
+    //TODO: logout api 호출
+    dispatch(logout());
+  };
+
   return (
     <>
       {/* //* 네비게이션 바 */}
@@ -14,13 +27,27 @@ export function Header() {
         {/* //* 상단바 */}
         <nav className={styles.topBar}>
           <ul className={styles.navWrapper}>
-            <li>로그인</li>
+            {isActive ? (
+              <li onClick={onLogout}>로그아웃</li>
+            ) : (
+              <>
+                <Link href={"/"}>
+                  <li>로그인</li>
+                </Link>
+                <VerticalDivider />
+                <Link href={"/"}>
+                  <li>회원가입</li>
+                </Link>
+              </>
+            )}
             <VerticalDivider />
-            <li>회원가입</li>
+            <Link href={"/"}>
+              <li>사이트맵</li>
+            </Link>
             <VerticalDivider />
-            <li>사이트맵</li>
-            <VerticalDivider />
-            <li>ENGLISH</li>
+            <Link href={"/"}>
+              <li>ENGLISH</li>
+            </Link>
           </ul>
         </nav>
 

--- a/src/components/header/header.module.css
+++ b/src/components/header/header.module.css
@@ -26,7 +26,7 @@
   align-items: center;
 }
 
-.navWrapper > li {
+.navWrapper li {
   color: white;
   font-size: 0.813rem;
 }

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,0 +1,7 @@
+import { useDispatch, useSelector, useStore } from "react-redux";
+import type { AppDispatch, AppStore, RootState } from "./store";
+
+// Use throughout your app instead of plain `useDispatch` and `useSelector`
+export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
+export const useAppSelector = useSelector.withTypes<RootState>();
+export const useAppStore = useStore.withTypes<AppStore>();

--- a/src/lib/provider.jsx
+++ b/src/lib/provider.jsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useRef } from "react";
+import { makeStore } from "./store";
+import { Provider } from "react-redux";
+
+function ReduxProvider({ children }) {
+  const storeRef = useRef();
+  if (!storeRef.current) {
+    // Create the store instance the first time this renders
+    storeRef.current = makeStore();
+  }
+
+  return <Provider store={storeRef.current}>{children}</Provider>;
+}
+
+export default ReduxProvider;

--- a/src/lib/slice/auth-slice.ts
+++ b/src/lib/slice/auth-slice.ts
@@ -1,0 +1,72 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+const Role = {
+  USER: "ROLE_USER",
+  ADMIN: "ROLE_ADMIN",
+} as const;
+
+type Role = (typeof Role)[keyof typeof Role]; // "ROLE_USER" | "ROLE_ADMIN"
+
+type UserState = {
+  isActive: boolean; // 로그인 상태
+  accessToken: string; // 발급받은 액세스 토큰
+  role: Role | null;
+};
+
+type InitialState = {
+  value: UserState;
+};
+
+const initialState: InitialState = {
+  value: {
+    isActive: false,
+    accessToken: "",
+    role: null,
+  },
+};
+
+export const auth = createSlice({
+  name: "auth",
+  initialState,
+  reducers: {
+    /**
+     * 사용자가 로그인 했을 때, 사용자 정보를 업데이트
+     * @param _state
+     * @param action
+     * @returns
+     */
+    login(_state, action: PayloadAction<string>) {
+      return {
+        value: {
+          isActive: true,
+          accessToken: action.payload,
+          role: "ROLE_USER",
+        },
+      };
+    },
+    /**
+     * 사용자가 로그아웃 했을 때, 사용자 정보를 초기화
+     * @returns
+     */
+    logout() {
+      return initialState;
+    },
+    /**
+     * 액세스 토큰을 재발급 받을 때, 재발급받은 토큰 저장
+     * @param state
+     * @param action
+     * @returns
+     */
+    updateToken(state, action: PayloadAction<string>) {
+      return {
+        value: {
+          ...state.value,
+          accessToken: action.payload,
+        },
+      };
+    },
+  },
+});
+
+export const { login, logout, updateToken } = auth.actions;
+export default auth.reducer;

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,0 +1,19 @@
+import { configureStore } from "@reduxjs/toolkit";
+import authReducer from "./slice/auth-slice";
+
+//? 이 파일은 NextJS에 도입된 Server Component 때문에 추가해야 한다.
+//     -> SPA에서는 state 값이 global하게 관리되고 모든 request마다 서로 공유되지만, RSC에서는 각 request마다 store를 새로 생성해주어야 한다.
+// 출처: https://redux.js.org/usage/nextjs#the-app-router-architecture-and-redux
+export const makeStore = () => {
+  return configureStore({
+    reducer: {
+      authReducer,
+    },
+  });
+};
+
+// Infer the type of makeStore
+export type AppStore = ReturnType<typeof makeStore>;
+// Infer the `RootState` and `AppDispatch` types from the store itself
+export type RootState = ReturnType<AppStore["getState"]>;
+export type AppDispatch = AppStore["dispatch"];


### PR DESCRIPTION
## 🌁 배경
- 유저의 로그인 상태를 어떻게 저장해야 할까?
    - 서버 api를 요청할 때, `access token`을 `Authorization header`에 담아서 보내야 한다. 

## 📝 문제상황
- 클라이언트 측에서 `access token`을 저장하고 있어야 한다. 
    - 1️⃣ 쿠키 ❌
        - 서버 측에서는 `Authorization header`로 인증하는 방식으로 구현했기 때문에 `httponly`, `secure` 쿠키는 사용할 수 없다. 
    - 2️⃣ 메모리 ❌
        - 클라이언트 메모리(`local storage`, `session storage`)를 사용할 수 있으나 XSS 공격에 매우 취약하므로 보류
    - 3️⃣ 코드 ✅
        - 현재 상황에서는 가장 최선의 방법인 것 같음. 하지만 토큰 값을 JS 코드 내에서 관리하면 **페이지가 새로고침 될 때마다 값이 초기화**되므로 이를 해결할 방법을 찾아야 한다.

## 💡 해결방안
- 동일 페이지 내에서는 `access token`이 유지되고, 페이지가 이동하면 값이 소멸된다. 
    - 페이지를 이동할 때마다 서버 측에서 `access token`을 재발급해준다. ❌
    👉🏻 불필요한 API 요청 증가로 서버 부담이 커지기 때문에 매우 좋지 않은 방법
    - `NextJS`의 layout 특성을 활용해보자 ✅
        - nextjs에서 제공하는 `layout`과 `Link` 태그를 사용하면, 페이지를 이동하더라도(= 유저가 url로 직접 이동하지 않는이상) layout 코드가 리프레시 되지 않는다. 
        - 현재 우리 프로젝트에서도 layout을 모든 페이지에서 사용할 것이므로, **유저 정보를 layout 코드 내에서 관리**하면 어떨까?
            - 이 방식을 사용하면 layout 페이지에서부터 **유저 정보를 모든 하위 컴포넌트로 전달해야 한다**는 `drilling` 문제가 발생한다.
            - 이 문제는 `상태관리 툴`을 활용하여 해결할 수 있다. 마침 [NextJS 공식문서 내에서 Redux 셋업에 대한 설명](https://redux.js.org/usage/nextjs)이 기재되어 있었으며, 리덕스 툴킷 사용으로 불필요한 코드 사용이 줄어든 것을 보아 이번 기회에 학습하며 사용해보면 좋을 것이라 생각했다.

## 🌟 결론
- 따라서 앞서 제안한 해결 방안 중에서 `Redux` 상태관리 툴 도입을 결정하게 되었고, 이에 따라 **유저가 url로 직접 페이지를 이동**하거나, **새로고침을 하지 않는 이상** 액세스 토큰 재발급 없이(= 서버측에 토큰 재발급 요청 없이) 서비스를 이용할 수 있을 것이다. 