### PR TITLE
[추가 작업] 스프린트 배정 작업 완료 후 추가 작업 진행

### DIFF
--- a/src/api/dataset.ts
+++ b/src/api/dataset.ts
@@ -142,6 +142,7 @@ export async function getDatasetDetail(id: number): Promise<DatasetDetail> {
   try {
     const result: DatasetDetailResponse = await fetch(
       `${SERVER_API}/api/dataset/${id}`,
+      { cache: "no-cache" },
     ).then((res) => res.json());
 
     console.log("detail result:", result);

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,6 +1,5 @@
-import Cookies from "js-cookie";
 import { decrypt } from "../utils/secure/token";
-import { GeneralResponse } from "./config";
+import { GeneralResponse, SERVER_API } from "./config";
 
 export type LoginInput = {
   email: string;
@@ -24,17 +23,14 @@ interface LoginResponse extends GeneralResponse {
  */
 export async function userLogin(params: LoginInput): Promise<LoginResponse> {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_SERVER_API}/api/user/login`,
-      {
-        headers: {
-          "Content-Type": "application/json",
-        },
-        method: "POST",
-        body: JSON.stringify(params),
-        credentials: "include",
+    const response = await fetch(`${SERVER_API}/api/user/login`, {
+      headers: {
+        "Content-Type": "application/json",
       },
-    );
+      method: "POST",
+      body: JSON.stringify(params),
+      credentials: "include",
+    });
 
     const result = await response.json();
 
@@ -51,16 +47,13 @@ export async function userLogin(params: LoginInput): Promise<LoginResponse> {
 export async function userLogout(): Promise<GeneralResponse> {
   try {
     const decryptedToken = decrypt(localStorage.getItem("session"));
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_SERVER_API}/api/user/logout`,
-      {
-        headers: {
-          Authorization: decryptedToken,
-        },
-        method: "POST",
-        credentials: "include",
+    const response = await fetch(`${SERVER_API}/api/user/logout`, {
+      headers: {
+        Authorization: decryptedToken,
       },
-    );
+      method: "POST",
+      credentials: "include",
+    });
 
     const result = await response.json();
     return result;
@@ -76,16 +69,13 @@ export async function userLogout(): Promise<GeneralResponse> {
 export async function reissueToken(): Promise<LoginResponse> {
   try {
     const decryptedToken = decrypt(localStorage.getItem("session"));
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_SERVER_API}/api/user/token`,
-      {
-        headers: {
-          Authorization: decryptedToken,
-        },
-        method: "POST",
-        credentials: "include",
+    const response = await fetch(`${SERVER_API}/api/user/token`, {
+      headers: {
+        Authorization: decryptedToken,
       },
-    );
+      method: "POST",
+      credentials: "include",
+    });
 
     const result = await response.json();
     return result;

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -14,7 +14,7 @@ export default function Layout({ children }) {
         <ReduxProvider>
           <div className={styles.container}>
             <Header />
-            <div className={styles.content}>{children}</div>
+            <div className="layoutPadding">{children}</div>
             <Footer />
           </div>
         </ReduxProvider>

--- a/src/app/search-result/[id]/detail.module.css
+++ b/src/app/search-result/[id]/detail.module.css
@@ -3,7 +3,8 @@
 }
 
 .mainInfoContainer {
-  padding: 3rem 0;
+  padding-top: 3rem;
+  padding-bottom: 3rem;
   background-color: #182531;
 }
 

--- a/src/app/search-result/[id]/page.tsx
+++ b/src/app/search-result/[id]/page.tsx
@@ -22,7 +22,7 @@ export default async function Page({ params }: { params: { id: string } }) {
   return (
     <div className={styles.root}>
       {/* //? 기본 정보 표시 */}
-      <div className={styles.mainInfoContainer}>
+      <div className={`noLayoutPadding ${styles.mainInfoContainer}`}>
         <div className={styles.basicInfoContainer}>
           <div className={styles.titleContainer}>
             <h1 className={styles.title}>{datasetDetail.title}</h1>

--- a/src/app/search-result/search-result.jsx
+++ b/src/app/search-result/search-result.jsx
@@ -282,18 +282,19 @@ export default function SearchResult({
           {/* //* 검색 결과 리스트 */}
           {/* //TODO: 실제 데이터 정보에 맞게 변경 */}
           {results.map((dataset, index) => (
-            <SimpleDatasetCard
-              key={dataset.datasetId}
-              title={dataset.title}
-              subtitle={dataset.description}
-              from={"입학처"}
-              type={"EXCEL"}
-              onClick={() => router.push(`search-result/${dataset.datasetId}`)}
-              style={{
-                marginTop: "1rem",
-                cursor: "pointer",
-              }}
-            />
+            <Link href={`/search-result/${dataset.datasetId}`}>
+              <SimpleDatasetCard
+                key={dataset.datasetId}
+                title={dataset.title}
+                subtitle={dataset.description}
+                from={dataset.organization}
+                type={dataset.type}
+                style={{
+                  marginTop: "1rem",
+                  cursor: "pointer",
+                }}
+              />
+            </Link>
           ))}
 
           {/* //* 페이지 리스트 */}

--- a/src/components/header/header.jsx
+++ b/src/components/header/header.jsx
@@ -21,17 +21,17 @@ export function Header() {
     dispatch(logout());
   };
 
-  //? 새로고침시 토큰이 사라지는 버그
-  useEffect(() => {
-    // token api로 access token 발급 요청
-    // -> 401 에러(REFRESH_EXPIRED)가 발생하는 경우: 비로그인 상태로 설정
-    // -> 정상 응답: login reducer 호출하여 로그인 상태로 전환
-  }, []);
-
   return (
     <>
       {/* //* 네비게이션 바 */}
-      <header className={styles.container}>
+      <header
+        className="layoutPadding"
+        style={{
+          paddingTop: "2.125rem",
+          paddingBottom: "2.125rem",
+          backgroundColor: "#003b71",
+        }}
+      >
         {/* //* 상단바 */}
         <nav className={styles.topBar}>
           <ul className={styles.navWrapper}>

--- a/src/components/scrap-button/scrap-button.tsx
+++ b/src/components/scrap-button/scrap-button.tsx
@@ -36,14 +36,14 @@ export function ScrapButton({
       return;
     }
 
-    await getDatasetDetail(datasetId).then((res) => setScrapCnt(res.scrap));
+    getDatasetDetail(datasetId).then((res) => setScrapCnt(res.scrap));
     setLike(!like);
   }, [like]);
 
   //* 첫 렌더링시 유저의 스크랩 여부 확인
   useEffect(() => {
     async function fetchLike() {
-      await getIsScrap(datasetId).then((res) => {
+      getIsScrap(datasetId).then((res) => {
         if (res === null) alert("스크랩 정보를 불러오는데 실패했습니다.");
         else setLike(res);
       });

--- a/src/components/simple-dataset-card/simple-dataset-card.tsx
+++ b/src/components/simple-dataset-card/simple-dataset-card.tsx
@@ -1,13 +1,35 @@
 import Image from "next/image";
 import styles from "./simple-dataset-card.module.css";
-import { DataType, DataOrganization, LikeEmpty } from "../../../public/svgs";
+import {
+  DataType as DataTypeImage,
+  DataOrganization,
+  LikeEmpty,
+} from "../../../public/svgs";
+import { DataType, Organization } from "../../constants/dataset-search-params";
+import { CSSProperties } from "react";
+
+interface SimpleDatasetCardProps {
+  title: string;
+  subtitle: string;
+  type: DataType;
+  from: Organization;
+  onClick?: () => any;
+  style?: CSSProperties;
+}
 
 /**
  *
- * @param {{title: string; subtitle: string; type: string; from: string; onClick?: MouseEventHandler<HTMLDivElement>; style?: CSSProperties }} param0
+ * @param param0
  * @returns
  */
-export function SimpleDatasetCard({ title, subtitle, type, from, onClick, style }) {
+export function SimpleDatasetCard({
+  title,
+  subtitle,
+  type,
+  from,
+  onClick,
+  style,
+}: SimpleDatasetCardProps) {
   return (
     <div onClick={onClick} className={styles.container} style={style}>
       <p className={styles.title}>{title}</p>
@@ -16,7 +38,7 @@ export function SimpleDatasetCard({ title, subtitle, type, from, onClick, style 
         <div>
           <Image
             className={styles.imageContainer}
-            src={DataType}
+            src={DataTypeImage}
             alt="파일 아이콘"
           />
           <p>{type}</p>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -11,11 +11,6 @@ import { encrypt } from "../utils/secure/token";
  */
 export async function handleToken(grantType: string, token: string) {
   const encryptedToken = encrypt(grantType + " " + token);
-  const accessExpiredInSeconds = process.env.NEXT_PUBLIC_ACCESS_EXPIRE;
-
-  if (!accessExpiredInSeconds) {
-    return process.env.EXPIRE_ENV_NOT_EXIST;
-  }
 
   localStorage.setItem("session", encryptedToken);
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -96,3 +96,57 @@ ul {
 li:hover {
   cursor: pointer;
 }
+
+/** padding */
+.layoutPadding {
+  padding: 0 8rem;
+}
+
+.noLayoutPadding {
+  margin: 0 -8rem;
+  padding: 0 8rem;
+}
+
+@media screen and (max-width: 680px) {
+  .layoutPadding {
+    padding: 0 2.5rem;
+  }
+
+  .noLayoutPadding {
+    margin: 0 -2.5rem;
+    padding: 0 2.5rem;
+  }
+}
+
+@media screen and (min-width: 681px) and (max-width: 1439px) {
+  .layoutPadding {
+    padding: 0 6rem;
+  }
+
+  .noLayoutPadding {
+    margin: 0 -6rem;
+    padding: 0 6rem;
+  }
+}
+
+@media screen and (min-width: 1440px) and (max-width: 1919px) {
+  .layoutPadding {
+    padding: 0 12rem;
+  }
+
+  .noLayoutPadding {
+    margin: 0 -12rem;
+    padding: 0 12rem;
+  }
+}
+
+@media screen and (min-width: 1920px) {
+  .layoutPadding {
+    padding: 0 20rem;
+  }
+
+  .noLayoutPadding {
+    margin: 0 -20rem;
+    padding: 0 20rem;
+  }
+}

--- a/src/styles/layout.module.css
+++ b/src/styles/layout.module.css
@@ -4,31 +4,3 @@
 
   background-color: white;
 }
-
-.content {
-  padding: 0 8rem;
-}
-
-@media screen and (max-width: 680px) {
-  .content {
-    padding: 0 2.5rem;
-  }
-}
-
-@media screen and (min-width: 681px) and (max-width: 1439px) {
-  .content {
-    padding: 0 6rem;
-  }
-}
-
-@media screen and (min-width: 1440px) and (max-width: 1919px) {
-  .content {
-    padding: 0 12rem;
-  }
-}
-
-@media screen and (min-width: 1920px) {
-  .content {
-    padding: 0 20rem;
-  }
-}


### PR DESCRIPTION
## 작업 내용
> 이번 스프린트에서 배정받은 작업을 일찍 끝내고 이전에 작성한 코드를 검토하며 추가 작업을 진행하였음

- 불필요한 코드 삭제
- ⭐️ 데이터셋 상세정보를 불러올 때, **스크랩 정보가 실제 정보와 일치하지 않는 문제**
    - 생각해보니 `Next`에서 fetch 데이터 캐싱을 기본적으로 지원하는데, 이게 원인인 것 같다. _(캐싱해둔 이전 정보를 불러옴)_
    - 따라서 데이터셋 상세정보 페이지를 fetch할 때 `no-cache` 옵션을 넣어주었다. 
        - 여기서 `no-cache`는 캐싱을 진행하되, **현재 캐시에 저장된 데이터가 stale한지 검증하는 과정을 매번** 진행하라는 의미이다. 
        - 근데 실제 적용해보면 **데이터 상세 정보 페이지에서는 캐싱이 적용되는 것 같지 않다.** _(dynamic route page 여서 그런건가?)_ 이 부분은 더 알아봐야겠다
    - 추가로 데이터셋 목록이 서버에서 갱신되었음에도 검색 결과 페이지에 노출되지 않는 문제가 있었다. 
        - 이는 `Next`의 `Router Cache`가 원인인 것으로 추정된다. 검색 결과 페이지의 경우 서버 컴포넌트로 정의한 상태인데, **서버 컴포넌트의 경우 특정 시간마다 _(조사해보니 30초 - dynamic / 5분 - static)_ 페이지를 캐싱**하기 때문이다. 
        - 따라서 직접 페이지를 새로고침하거나 일정 시간이 지나지 않는 한, 업데이트된 내역을 바로 화면에서 확인할 수 없었던 것. 하지만 우리 서비스에서 데이터 목록은 실시간성이 크게 중요한 부분은 아니므로 _(더욱이 30초 차이면 서비스 이용에 지장은 주지 않을 것이라 생각)_ 유지
- ⭐️ 검색결과 페이지에서 데이터셋 상세 페이지로 라우팅 -> `Link` 태그로 변경
    - 기존 코드에서 상세 페이지로 이동하는 것을 onClick 을 사용하여 router.push()를 사용했음
    - 이는 `a 태그`가 아닌 `window 객체`로 동작하기 때문에 해당 페이지를 `prefetch` 할 수 없다. **즉, `SEO`에 좋지 않음** _(대체 이전에 왜 router로 짠거지?.. 이런 고민 없이 그냥 막 짜둔 것 같다 ..)_
    - 따라서 `SEO` 개선을 위해 이를 `Link` 태그로 이동하는 것으로 변경
[04.11 추가]
- 반응형 레이아웃 패딩 값 관리 방식 수정

## 주요 변경 사항
- 기존에는 `Layout` 컴포넌트에서 패딩값을 관리했기 때문에, **패딩이 불필요한 컴포넌트는 스타일링이 어려웠음**
    - 패딩 값은 _뷰포트 크기에 따라 반응형으로 바뀌기 때문에_ 상수 값으로 관리하기 어려움
    - 따라서 `global.css`에 `layoutPadding`과 `noLayoutPadding` 클래스를 추가하였음
        - `layoutPadding` - 헤더, 푸터를 제외한 나머지 자식 컴포넌트에 모두 적용되는 레이아웃 패딩 값
        - `noLayoutPadding` - **레이아웃 패딩이 필요하지 않은 자식 컴포넌트에서 사용**

**[예시]**
예를 들어 아래 표시한 컴포넌트의 경우 레이아웃 패딩 값을 무시해야 하는 컴포넌트이다. 
<img width="858" alt="image" src="https://github.com/ckan-project/ckan-front/assets/63039855/bfa4e63a-0b00-40b5-9703-d198524eb352">
따라서 해당 컴포넌트에 다음과 같이 스타일 클래스 명을 지정하면 위처럼 레이아웃 패딩을 무시하여 스타일을 적용할 수 있다. 
```jsx
<div className={`noLayoutPadding ${styles.mainInfoContainer}`}>
```
단, 해당 컴포넌트 내부 상-하 패딩을 따로 줘야하는 경우에는 아래와 같이 패딩 값을 따로 선언해야 하는 번거로움이 남아있다.
```css
.mainInfoContainer {
  padding-top: 3rem;
  padding-bottom: 3rem;
  background-color: #182531;
}
```