### PR TITLE
[추가 작업] 검색 결과 스크린 page 관련 오류 해결

### DIFF
--- a/src/app/search-result/search-result.jsx
+++ b/src/app/search-result/search-result.jsx
@@ -39,7 +39,7 @@ export default function SearchResult({
   initPage,
 }) {
   // ? 페이지 값 없이 렌더링하는 경우 -> 1페이지를 기본 페이지로 설정
-  const _initPage = initPage ? initPage : "1";
+  const _initPage = initPage ? initPage : "0";
 
   const searchParams = useSearchParams();
   const pathName = usePathname();
@@ -277,12 +277,14 @@ export default function SearchResult({
           </div>
 
           {/* //? division line */}
-          <div className={styles.divisionLine} />
+          <div className={styles.divisionLine} style={{ marginBottom: "2rem" }} />
 
           {/* //* 검색 결과 리스트 */}
-          {/* //TODO: 실제 데이터 정보에 맞게 변경 */}
           {results.map((dataset, index) => (
-            <Link href={`/search-result/${dataset.datasetId}`}>
+            <Link
+              href={`/search-result/${dataset.datasetId}`}
+              key={`result${index}`}
+            >
               <SimpleDatasetCard
                 key={dataset.datasetId}
                 title={dataset.title}
@@ -291,66 +293,76 @@ export default function SearchResult({
                 type={dataset.type}
                 style={{
                   marginTop: "1rem",
-                  cursor: "pointer",
                 }}
               />
             </Link>
           ))}
 
           {/* //* 페이지 리스트 */}
-          <div
-            className={styles.pagesContainer}
-            style={{
-              margin: "0.75rem 0 2.25rem 0",
-            }}
-          >
-            <div className={styles.pagesWrapper}>
-              {/* //? 이전 페이지 버튼 */}
-              <Link
-                href={`${pathName}?${updateQueryString(
-                  "create",
-                  "page",
-                  Math.max(1, parseInt(_initPage) - 1),
-                )}`}
-              >
-                <Image src={PreviousButton} alt="이전 페이지 버튼" />
-              </Link>
+          {totalPage > 0 && (
+            <div
+              className={styles.pagesContainer}
+              style={{
+                margin: "5.625rem 0 2.25rem 0",
+              }}
+            >
+              <div className={styles.pagesWrapper}>
+                {/* //? 이전 페이지 버튼 */}
+                {parseInt(_initPage) > 0 && (
+                  <Link
+                    href={
+                      _initPage == 1
+                        ? `${pathName}?${updateQueryString("remove", "page")}`
+                        : `${pathName}?${updateQueryString(
+                            "create",
+                            "page",
+                            Math.max(1, parseInt(_initPage) - 1),
+                          )}`
+                    }
+                  >
+                    <Image src={PreviousButton} alt="이전 페이지 버튼" />
+                  </Link>
+                )}
 
-              {/* //? 페이지 버튼 목록 */}
-              {new Array(totalPage).fill(0).map((_, index) => (
-                <Link
-                  href={`${pathName}?${updateQueryString(
-                    "create",
-                    "page",
-                    index + 1,
-                  )}`}
-                  key={index}
-                  className={styles.pageButton}
-                  style={
-                    _initPage == index + 1
-                      ? {
-                          backgroundColor: "#767676",
-                          color: "white",
-                        }
-                      : {}
-                  }
-                >
-                  {index + 1}
-                </Link>
-              ))}
+                {/* //? 페이지 버튼 목록 */}
+                {new Array(totalPage).fill(0).map((_, index) => (
+                  <Link
+                    // 첫 페이지의 경우 page 파라미터를 넘기면 안 되므로, 파라미터 삭제
+                    href={
+                      index !== 0
+                        ? `${pathName}?${updateQueryString("create", "page", index)}`
+                        : `${pathName}?${updateQueryString("remove", "page")}`
+                    }
+                    key={index}
+                    className={styles.pageButton}
+                    style={
+                      _initPage == index
+                        ? {
+                            backgroundColor: "#767676",
+                            color: "white",
+                          }
+                        : {}
+                    }
+                  >
+                    {index + 1}
+                  </Link>
+                ))}
 
-              {/* //? 다음 페이지 버튼 */}
-              <Link
-                href={`${pathName}?${updateQueryString(
-                  "create",
-                  "page",
-                  Math.min(totalPage, parseInt(_initPage) + 1),
-                )}`}
-              >
-                <Image src={NextButton} alt="다음 페이지 버튼" />
-              </Link>
+                {/* //? 다음 페이지 버튼 */}
+                {parseInt(_initPage) < totalPage - 1 && (
+                  <Link
+                    href={`${pathName}?${updateQueryString(
+                      "create",
+                      "page",
+                      Math.min(totalPage, parseInt(_initPage) + 1),
+                    )}`}
+                  >
+                    <Image src={NextButton} alt="다음 페이지 버튼" />
+                  </Link>
+                )}
+              </div>
             </div>
-          </div>
+          )}
         </section>
       </main>
     </>

--- a/src/app/search-result/search-result.jsx
+++ b/src/app/search-result/search-result.jsx
@@ -290,6 +290,7 @@ export default function SearchResult({
                 title={dataset.title}
                 subtitle={dataset.description}
                 from={dataset.organization}
+                view={dataset.view}
                 type={dataset.type}
                 style={{
                   marginTop: "1rem",

--- a/src/components/simple-dataset-card/simple-dataset-card.tsx
+++ b/src/components/simple-dataset-card/simple-dataset-card.tsx
@@ -13,6 +13,7 @@ interface SimpleDatasetCardProps {
   subtitle: string;
   type: DataType;
   from: Organization;
+  view: number;
   onClick?: () => any;
   style?: CSSProperties;
 }
@@ -27,6 +28,7 @@ export function SimpleDatasetCard({
   subtitle,
   type,
   from,
+  view,
   onClick,
   style,
 }: SimpleDatasetCardProps) {
@@ -58,7 +60,7 @@ export function SimpleDatasetCard({
 
       <div className={styles.hoverContainer}>
         <p>
-          <Image src={LikeEmpty} alt="스크랩 아이콘" /> 5 조회수 10
+          조회수 {view} <Image src={LikeEmpty} alt="스크랩 아이콘" /> 5
         </p>
       </div>
     </div>


### PR DESCRIPTION
## 작업 내용
- page 인덱스가 백엔드 api에서 요구하는 것과 프론트에서 구현한 값이 서로 일치하지 않는 문제
    - 백엔드에서는 page 값이 **0부터 시작**하나, 프론트는 **1부터 시작** 👉🏻 관련 코드 수정 완료
- `백엔드 검색 결과 api`에서는 검색 결과 첫 페이지에 접근하는 경우, page 파라미터를 제외하고 호출해야 한다. 
    - 따라서 첫 페이지에 접근하는 경우에는 **page 파라미터를 삭제**하는 것으로 코드 수정
- 데이터 셋 마우스를 호버링 시 노출되는 조회수를 백엔드 api와 연결