### PR TITLE
[Fix] 클라이언트 컴포넌트 -> 서버 컴포넌트 이동 오류

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -2,7 +2,6 @@ import Image from "next/image";
 import React from "react";
 import { MainLogoBlue } from "../../../public/svgs";
 import styles from "./layout.module.css";
-import Link from "next/link";
 
 export const metadata = {
   title: "한양대학교 데이터 포털 로그인",
@@ -14,13 +13,13 @@ function Layout({ children }) {
       <body>
         <div className={styles.root}>
           <div className={styles.header}>
-            <Link href={"/"}>
+            <a href={"/"}>
               <Image
                 className={styles.logoContainer}
                 src={MainLogoBlue}
                 alt="한양대 ERICA 데이터포털"
               />
-            </Link>
+            </a>
           </div>
           {children}
         </div>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,4 +1,4 @@
-"use client"; //? client componet - NextJS 13
+"use client";
 
 import { useState } from "react";
 import styles from "./login.module.css";
@@ -8,17 +8,12 @@ import { ID, PW } from "../../../../public/svgs";
 import { VerticalDivider, FilterCheckButton } from "../../../components";
 import { userLogin } from "../../../api/user";
 import { handleToken } from "../../../lib/actions";
-import { useRouter } from "next/navigation";
 import { KakaoLoginLarge } from "../../../../public/images";
 
 export default function Login() {
-  console.log("this is Login client component");
-
   const [email, setEmail] = useState<string>();
   const [password, setPassword] = useState<string>();
   const [autoLogin, setAutoLogin] = useState<boolean>(false);
-
-  const router = useRouter();
 
   const handleLogin = async () => {
     const response = await userLogin({
@@ -33,10 +28,8 @@ export default function Login() {
     }
     const result = response.result;
 
-    handleToken(result.grantType, result.accessToken);
-    console.log("!!!");
-    router.push("/");
-    router.refresh();
+    await handleToken(result.grantType, result.accessToken);
+    window.location.replace("/");
   };
 
   return (

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1,7 +1,9 @@
 "use client";
 
-import { encrypt } from "../utils/secure/token";
+import { decrypt, encrypt } from "../utils/secure/token";
 // import { cookies } from "next/headers";
+
+const tokenKey = process.env.NEXT_PUBLIC_TOKEN_KEY;
 
 /**
  * 응답받은 토큰을 암호화하여 쿠키에 저장하는 메서드
@@ -12,10 +14,18 @@ import { encrypt } from "../utils/secure/token";
 export async function handleToken(grantType: string, token: string) {
   const encryptedToken = encrypt(grantType + " " + token);
 
-  localStorage.setItem("session", encryptedToken);
+  localStorage.setItem(tokenKey, encryptedToken);
 
   // cookies().set("session", encryptedToken, {
   //   // sameSite: "strict", // 배포 후 적용
   //   path: "/",
   // });
+}
+
+export async function getToken(): Promise<string | null> {
+  const item = localStorage.getItem(tokenKey);
+  if (item === null) return null;
+
+  const decryptedToken = decrypt(item);
+  return decryptedToken;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export async function middleware(request: NextRequest) {
+  if (request.nextUrl.pathname === "/login") {
+    const { cookies } = request;
+    if (cookies.has("refreshToken")) {
+      return NextResponse.redirect(new URL("/", request.nextUrl.origin));
+    }
+    return NextResponse.next();
+  }
+  // return NextResponse.redirect(new URL("/", request.nextUrl.origin));
+}
+
+export const config = {
+  matcher: ["/login"],
+};


### PR DESCRIPTION
## 문제 상황
로그인 화면(클라이언트 컴포넌트)에서 메인 화면(서버 컴포넌트)으로 넘어갈 때, `Link 태그`를 사용하면 **빈 html 파일** 반환
생각해보니 서버 컴포넌트는 **서버에서 요청을 받으면 해당하는 html 파일을 반환하는 구조**이다. 하지만 클라이언트 컴포넌트 내부에서 `Link 태그`로 연결하면 SPA로 동작한다. 즉, **js 파일 내에서 페이지를 찾기 때문에 서버 컴포넌트를 호출할 수 없는 것**이다.

## 작업 내용
따라서 `클라이언트 컴포넌트`에서 메인 페이지와 같이 `서버 컴포넌트`를 렌더링하는 경우, `a 태그` 혹은 `window` 객체를 활용하여 redirect하도록 코드를 변경했다. 